### PR TITLE
Update Java CI Workflow to use Gradle native gradle-build-action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - '[3-9]+.[0-9]+.x'
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,12 +18,6 @@ jobs:
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -39,32 +34,47 @@ jobs:
         with:
           stack-version: 7.7.1
       - name: Run Tests
-        run: ./gradlew check
+        if: github.event_name == 'pull_request'
+        id: tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+      - name: Run Build
+        if: github.event_name == 'push'
+        id: build
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+        with:
+          arguments: build
       - name: Publish Test Report
-        if: failure()
+        if: steps.build.outcome == 'failure' || steps.tests.outcome == 'failure'
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Run Assemble
-        if: success() && github.event_name == 'push' && matrix.java == '8'
-        run: ./gradlew assemble
       - name: Publish to repo.grails.org
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        uses: gradle/gradle-build-action@v2
+        if: steps.build.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        run: |
-          ./gradlew publish
-          echo "Publishing Docs..."
-          ./gradlew docs
-      - name: Publish to Github Pages
+        with:
+          arguments: publish
+      - name: Generate Documentation
+        id: docs
+        uses: gradle/gradle-build-action@v2
         if: success() && github.event_name == 'push' && matrix.java == '8'
+        with:
+          arguments: docs
+      - name: Publish to Github Pages
+        if: steps.publish.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
           TARGET_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages
           FOLDER: build/docs
+          DOC_FOLDER: gh-pages
           COMMIT_EMAIL: behlp@objectcomputing.com
           COMMIT_NAME: Puneet Behl


### PR DESCRIPTION
In this commit we have removed the manual caching logic from Java CI workflow. Instead, we now rely on Gradle native gradle-build-action. This should improve the build performance.