### PR TITLE
Clean up build.gradle: remove duplicate dependencies and test config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,12 +90,10 @@ dependencies {
 
     testRuntimeOnly 'org.apache.tomcat:tomcat-jdbc'
 
-    testCompileOnly "org.grails:grails-web-testing-support"
-    testCompileOnly 'org.locationtech.jts:jts-core:1.20.0'
-    testCompileOnly 'com.googlecode.json-simple:json-simple:1.1.1'
-
     testImplementation "org.grails:grails-gorm-testing-support"
     testImplementation "org.grails:grails-web-testing-support"
+    testImplementation 'org.locationtech.jts:jts-core:1.20.0'
+    testImplementation 'com.googlecode.json-simple:json-simple:1.1.1'
     testImplementation "org.spockframework:spock-core"
 
     constraints {
@@ -142,10 +140,6 @@ apply from: "gradle/documentation.gradle"
 
 grails {
     pathingJar = true
-}
-
-tasks.withType(Test) {
-    useJUnitPlatform()
 }
 
 javadocJar {


### PR DESCRIPTION
## Summary

- Remove duplicate `grails-web-testing-support` declaration (was in both `testCompileOnly` and `testImplementation`)
- Move `jts-core` and `json-simple` from `testCompileOnly` to `testImplementation` since they are needed at test runtime
- Remove duplicate `tasks.withType(Test) { useJUnitPlatform() }` block already configured earlier in the file

## Related

- Tracked `org.elasticsearch.common.xcontent` deprecation in #240 (not a code change - for the Grails 7 port)