### PR TITLE
Fix snapshot publishing and integration test compatibility with ES 7.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,8 @@ jobs:
 
       - name: "📤 Publish Gradle Snapshot Artifacts"
         env:
-          MAVEN_PUBLISH_URL: 'https://central.sonatype.com/repository/maven-snapshots/'
-          MAVEN_PUBLISH_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
-          MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
+          NEXUS_PUBLISH_USERNAME: ${{ secrets.NEXUS_PUBLISH_USERNAME }}
+          NEXUS_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PUBLISH_PASSWORD }}
         run: >
           ./gradlew publish
           --no-build-cache

--- a/build.gradle
+++ b/build.gradle
@@ -192,17 +192,6 @@ publishing {
             }
         }
     }
-    repositories {
-        if (System.getenv('MAVEN_PUBLISH_URL')) {
-            maven {
-                name = 'mavenCentral'
-                url = System.getenv('MAVEN_PUBLISH_URL')
-                credentials {
-                    username = System.getenv('MAVEN_PUBLISH_USERNAME') ?: ''
-                    password = System.getenv('MAVEN_PUBLISH_PASSWORD') ?: ''
-                }
-            }
-        }
     }
 }
 
@@ -210,6 +199,7 @@ nexusPublishing {
     repositories {
         sonatype {
             nexusUrl = uri('https://ossrh-staging-api.central.sonatype.com/service/local/')
+            snapshotRepositoryUrl = uri('https://central.sonatype.com/repository/maven-snapshots/')
             username = System.getenv('NEXUS_PUBLISH_USERNAME') ?: ''
             password = System.getenv('NEXUS_PUBLISH_PASSWORD') ?: ''
         }


### PR DESCRIPTION
## Summary

Fixes the snapshot publishing failure and integration test failures that occurred after merging #234.

### Publishing fix
- Removed the duplicate `publishing.repositories` block that created a manual `mavenCentral` repo via `MAVEN_PUBLISH_URL`
- Set `snapshotRepositoryUrl` on the nexus-publish sonatype config to point to `https://central.sonatype.com/repository/maven-snapshots/`
- The nexus-publish plugin was defaulting to the old `oss.sonatype.org` for snapshots (returns 405 Not Allowed)
- Simplified CI env vars since the nexus-publish plugin reads credentials from `build.gradle` directly

### Integration test fix
- `ElasticSearchMappingFactorySpec` deletes all ES indexes before reinstalling mappings in setup/cleanup, preventing mapping conflicts when ES 7.15.2 rejects mapping updates that 7.7 accepted silently
- Removed deprecated `index.store.type: simplefs` from test config

### CI fixes
- Use `ubuntu-22.04` runners (ES 7.15.2's bundled JDK crashes on cgroups v2 default in ubuntu-24.04)
- Increased ES Docker heap from 512m to 1g with diagnostic logging on startup failure