### PR TITLE
Fix build.gradle syntax error from publishing block removal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,6 @@ publishing {
             }
         }
     }
-    }
 }
 
 nexusPublishing {


### PR DESCRIPTION
## Summary

The `publishing.repositories` block removal in the previous merge left a dangling closing brace at line 195, causing a Groovy parse error that fails the build immediately.

One-line fix: remove the extra `}`.