### PR TITLE
#240 migrate xcontent

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,7 +26,7 @@ In order to simply the versioning, with v3.0.0.M1 the Elasticsearch Grails plugi
 
 |4.0.0
 |5.3.x - 6.x.x
-|7.15.2
+|7.17.29
 
 |3.0.0
 |4.0.x - 6.x.x

--- a/build.gradle
+++ b/build.gradle
@@ -76,11 +76,12 @@ dependencies {
     implementation "org.grails.plugins:cache"
     implementation "org.hibernate:hibernate-ehcache"
     implementation "org.apache.logging.log4j:log4j-api:2.24.3"
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.24.3'
+    implementation "org.apache.logging.log4j:log4j-core:2.24.3"
 
     api "org.elasticsearch:elasticsearch:${elasticsearchVersion}"
-    api group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: elasticsearchVersion
-    api group: 'org.elasticsearch.client', name: 'elasticsearch-rest-high-level-client', version: elasticsearchVersion
+    api "org.elasticsearch.client:elasticsearch-rest-client:${elasticsearchVersion}"
+    api "org.elasticsearch.client:elasticsearch-rest-high-level-client:${elasticsearchVersion}"
+    api "org.elasticsearch:elasticsearch-x-content:${elasticsearchVersion}"
     implementation "org.mongodb:mongodb-driver:3.9.1"
     implementation 'org.locationtech.spatial4j:spatial4j:0.8'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=4.0.0-SNAPSHOT
 grailsVersion=5.3.6
 grailsGradlePluginVersion=5.3.1
 gormHibernateVersion=7.0.5
-elasticsearchVersion=7.16.3
+elasticsearchVersion=7.17.29
 asciidoctorVersion=4.0.3
 
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=4.0.0-SNAPSHOT
 grailsVersion=5.3.6
 grailsGradlePluginVersion=5.3.1
 gormHibernateVersion=7.0.5
-elasticsearchVersion=7.15.2
+elasticsearchVersion=7.16.3
 asciidoctorVersion=4.0.3
 
 org.gradle.caching=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
+++ b/grails-app/services/grails/plugins/elasticsearch/ElasticSearchService.groovy
@@ -28,12 +28,6 @@ import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestHighLevelClient
 import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.xcontent.DeprecationHandler
-import org.elasticsearch.common.xcontent.NamedXContentRegistry
-import org.elasticsearch.common.xcontent.XContent
-import org.elasticsearch.common.xcontent.XContentLocation
-import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.json.JsonXContent
 import org.elasticsearch.index.query.Operator
 import org.elasticsearch.index.query.QueryBuilder
 import org.elasticsearch.index.query.QueryStringQueryBuilder
@@ -48,6 +42,12 @@ import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder
 import org.elasticsearch.search.sort.SortBuilder
 import org.elasticsearch.search.sort.SortOrder
+import org.elasticsearch.xcontent.DeprecationHandler
+import org.elasticsearch.xcontent.NamedXContentRegistry
+import org.elasticsearch.xcontent.XContent
+import org.elasticsearch.xcontent.XContentLocation
+import org.elasticsearch.xcontent.XContentParser
+import org.elasticsearch.xcontent.json.JsonXContent
 
 import java.util.function.Supplier
 

--- a/src/main/groovy/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/conversion/JSONDomainFactory.groovy
@@ -23,12 +23,12 @@ import grails.plugins.elasticsearch.mapping.DomainEntity
 import grails.plugins.elasticsearch.mapping.DomainReflectionService
 import grails.plugins.elasticsearch.mapping.SearchableClassMapping
 import grails.plugins.elasticsearch.unwrap.DomainClassUnWrapperChain
-import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.xcontent.XContentBuilder
 
 import java.beans.PropertyEditor
 import java.sql.Timestamp
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder
 
 /**
  * Marshall objects as JSON.

--- a/src/main/groovy/grails/plugins/elasticsearch/index/IndexRequestQueue.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/index/IndexRequestQueue.groovy
@@ -30,7 +30,7 @@ import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestHighLevelClient
 import org.elasticsearch.common.unit.ByteSizeUnit
 import org.elasticsearch.common.unit.ByteSizeValue
-import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.xcontent.XContentBuilder
 import org.elasticsearch.core.TimeValue
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/src/main/groovy/grails/plugins/elasticsearch/util/AbstractQueryBuilderParser.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/util/AbstractQueryBuilderParser.groovy
@@ -2,9 +2,9 @@ package grails.plugins.elasticsearch.util
 
 import groovy.transform.CompileStatic
 import org.elasticsearch.common.ParsingException
-import org.elasticsearch.common.xcontent.NamedObjectNotFoundException
-import org.elasticsearch.common.xcontent.XContentLocation
-import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.xcontent.NamedObjectNotFoundException
+import org.elasticsearch.xcontent.XContentLocation
+import org.elasticsearch.xcontent.XContentParser
 import org.elasticsearch.index.query.QueryBuilder
 
 /**

--- a/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
@@ -20,7 +20,6 @@
 package grails.plugins.elasticsearch.util
 
 import org.elasticsearch.common.bytes.BytesReference
-import org.elasticsearch.xcontent.XContent
 import org.elasticsearch.xcontent.XContentBuilder
 import org.elasticsearch.xcontent.XContentFactory
 import org.elasticsearch.xcontent.XContentType
@@ -47,7 +46,7 @@ class GXContentBuilder extends GroovyObjectSupport {
     }
 
     String buildAsString(Closure c) {
-        XContent builder = XContentFactory.contentBuilder(XContentType.JSON)
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)
         def json = build(c)
         builder.map(json)
         return builder.string()

--- a/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
+++ b/src/main/groovy/grails/plugins/elasticsearch/util/GXContentBuilder.groovy
@@ -20,9 +20,10 @@
 package grails.plugins.elasticsearch.util
 
 import org.elasticsearch.common.bytes.BytesReference
-import org.elasticsearch.common.xcontent.XContentBuilder
-import org.elasticsearch.common.xcontent.XContentFactory
-import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.xcontent.XContent
+import org.elasticsearch.xcontent.XContentBuilder
+import org.elasticsearch.xcontent.XContentFactory
+import org.elasticsearch.xcontent.XContentType
 
 /**
  * This is a hacked version of EC's GXContentBuilder with patched property delegation.
@@ -46,7 +47,7 @@ class GXContentBuilder extends GroovyObjectSupport {
     }
 
     String buildAsString(Closure c) {
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON)
+        XContent builder = XContentFactory.contentBuilder(XContentType.JSON)
         def json = build(c)
         builder.map(json)
         return builder.string()


### PR DESCRIPTION
This should fix https://github.com/grails-plugins/grails-elasticsearch/issues/240 and updates ElasticSearch to the latest 7.x release.