### PR TITLE
chore: improve gh-pages index.html

### DIFF
--- a/build-logic/src/main/groovy/config.docs.gradle
+++ b/build-logic/src/main/groovy/config.docs.gradle
@@ -67,34 +67,65 @@ tasks.register('ghPagesRootIndexPage') {
     group = 'documentation'
 
     def templateFile = docProject.map { it.layout.projectDirectory.file('src/docs/index.tmpl') }
-    def outputFile   = rootProject.layout.buildDirectory.file('docs/ghpages.html')
+    def outputFile = rootProject.layout.buildDirectory.file('docs/ghpages.html')
 
     inputs.file(templateFile)
     outputs.file(outputFile)
 
     doLast {
+        def githubUser = rootProject.findProperty('githubUser') as String
+        def githubProject = rootProject.findProperty('githubProject') as String
+
         List<String> versions = []
+        String latestVersion = ""
         try {
-            def conn = URI.create('https://api.github.com/repos/grails-plugins/grails-elasticsearch/contents/?ref=gh-pages').toURL().openConnection()
+            def conn = URI.create("https://api.github.com/repos/${githubUser}/${githubProject}/contents/?ref=gh-pages").toURL().openConnection()
             conn.setRequestProperty('Accept', 'application/vnd.github+json')
             conn.setRequestProperty('User-Agent', 'gradle-docs-build')
-            def parsed = new JsonSlurper().parse(conn.inputStream)
+            def parsed = new groovy.json.JsonSlurper().parse(conn.inputStream)
+
             versions = (parsed as List)
-                .findAll { it.type == 'dir' }
-                .collect { it.name as String }
-                .findAll { it ==~ /\d+\.\d+\.(\d+|x)(-.*)?/ }
-                .sort()
-                .reverse()
+                    .findAll { it.type == 'dir' }
+                    .collect { it.name as String }
+                    .findAll { it ==~ /\d+\.\d+\.(\d+|x)(-.*)?/ }
+                    .toSorted { a, b ->
+                        // Parse into [major, minor, patch, qualifier]
+                        // patch 'x' becomes -1 so it sorts below any numeric patch
+                        // qualifier '' (stable) sorts above any pre-release string
+                        def parseVer = { String v ->
+                            def m = v =~ /^(\d+)\.(\d+)\.(x|\d+)(?:-(.+))?$/
+                            if (!m) return [0, 0, -2, '']
+                            [m[0][1] as int, m[0][2] as int, m[0][3] == 'x' ? -1 : m[0][3] as int, m[0][4] ?: '']
+                        }
+                        def av = parseVer(a)
+                        def bv = parseVer(b)
+                        return bv[0] <=> av[0] ?: bv[1] <=> av[1] ?: bv[2] <=> av[2] ?:
+                                (!av[3] && bv[3] ? -1 : av[3] && !bv[3] ? 1 : bv[3] <=> av[3]) // RC and other postfix versions
+                    }
+            latestVersion = versions ? versions.first() : ''
         } catch (Exception e) {
             logger.warn("ghPagesRootIndexPage: could not fetch GitHub versions — ${e.message}")
         }
 
         String optionsHtml = versions
-            ? versions.collect { v -> "<option value=\"${v}\">${v}</option>" }.join('\n                    ')
-            : '<option value="" disabled>No previous versions available</option>'
+                ? versions.collect { v -> "<option value=\"${v}\">${v}</option>" }.join('\n                    ')
+                : '<option value="" disabled>No previous versions available</option>'
+
+        def tokens = [
+                '@LATEST_VERSION@'        : latestVersion,
+                '@OTHER_VERSIONS_OPTIONS@': optionsHtml,
+                '@GITHUB_REPO_URL@'       : "https://github.com/${githubUser}/${githubProject}",
+                '@GITHUB_ORG_URL@'        : "https://github.com/${githubUser}",
+                '@PROJECT_TITLE@'         : "${projectTitle}",
+                '@PROJECT_DESCRIPTION@'   : "${projectDescription}",
+                '@PROJECT_ORG@'           : "${projectOrg}",
+                '@REPO_SLUG@'             : githubProject,
+        ]
 
         def out = outputFile.get().asFile
         out.parentFile.mkdirs()
-        out.text = templateFile.get().asFile.text.replace('@OTHER_VERSIONS_OPTIONS@', optionsHtml)
+        def content = templateFile.get().asFile.text
+        tokens.each { token, value -> content = content.replace(token, value) }
+        out.text = content
     }
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,10 +17,9 @@ def asciidoctorAttributes = [
         idprefix            : '',
         idseparator         : '-',
         version             : project.version,
-        projectUrl          : 'https://github.com/grails-plugins/grails-elasticsearch',
+        projectUrl: "https://github.com/${rootProject.findProperty('githubUser')}/${rootProject.findProperty('githubProject')}",
         sourcedir           : "${rootProject.allprojects.find { it.name == 'grails-elasticsearch' }.projectDir}/src/main/groovy",
         grailsVersion       : grailsVersion
-//        grailsDocBase       : "https://grails.apache.org/docs/${resolveGrailsDocsDirName(project.grailsVersion)}"
 ]
 
 tasks.named('asciidoctor', AsciidoctorTask) {

--- a/docs/src/docs/index.tmpl
+++ b/docs/src/docs/index.tmpl
@@ -1,132 +1,390 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-    "http://www.w3.org/TR/html4/loose.dtd">
-
+<!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title>Grails Elasticsearch Plugin @ GitHub</title>
-    <style type="text/css">
-      body {
-        margin-top: 1.0em;
-        font-family: "Helvetica,Arial,FreeSans";
-      }
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@PROJECT_TITLE@</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #1a9f6c;
+            --primary-dark: #158259;
+            --text-color: #1f2937;
+            --text-muted: #6b7280;
+            --bg-color: #f9fafb;
+            --card-bg: #ffffff;
+            --border-color: #e5e7eb;
+            --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        }
 
-      #container {
-        margin: 0 auto;
-        margin-left: 50px;
-        margin-right: 50px;
-      }
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
 
-      .propName {
-        font-weight: bold;
-      }
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
 
-      h1 {
-        color: #00CC00;
-        margin-bottom: 3px;
-      }
+        .hero {
+            background: linear-gradient(135deg, #1a9f6c 0%, #0d7a52 100%);
+            color: white;
+            padding: 4rem 2rem;
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
 
-      td {
-        padding: 2px 5px;
-      }
+        .hero::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+            opacity: 0.5;
+        }
+
+        .hero-content {
+            position: relative;
+            z-index: 1;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        .hero h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+            letter-spacing: -0.025em;
+        }
+
+        .hero .subtitle {
+            font-size: 1.125rem;
+            opacity: 0.9;
+            font-weight: 400;
+        }
+
+        .github-link {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            z-index: 10;
+            background: rgba(255, 255, 255, 0.15);
+            padding: 0.5rem 1rem;
+            border-radius: 0.5rem;
+            color: white;
+            text-decoration: none;
+            font-size: 0.875rem;
+            font-weight: 500;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: background-color 0.2s ease;
+        }
+
+        .github-link:hover {
+            background: rgba(255, 255, 255, 0.25);
+        }
+
+        .github-link svg {
+            width: 20px;
+            height: 20px;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 3rem 1.5rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--text-color);
+            margin-bottom: 1.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .section-title::before {
+            content: '';
+            width: 4px;
+            height: 1.5rem;
+            background: var(--primary-color);
+            border-radius: 2px;
+        }
+
+        .docs-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 1.5rem;
+            margin-bottom: 3rem;
+        }
+
+        .doc-card {
+            background: var(--card-bg);
+            border-radius: 1rem;
+            padding: 1.5rem;
+            box-shadow: var(--shadow);
+            border: 1px solid var(--border-color);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .doc-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-lg);
+        }
+
+        .doc-card h3 {
+            font-size: 1.125rem;
+            font-weight: 600;
+            color: var(--text-color);
+            margin-bottom: 0.25rem;
+        }
+
+        .doc-card .version-badge {
+            display: inline-block;
+            font-size: 0.75rem;
+            font-weight: 500;
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            margin-bottom: 1rem;
+        }
+
+        .doc-card .version-badge.snapshot {
+            background: #fef3c7;
+            color: #92400e;
+        }
+
+        .doc-card .version-badge.latest {
+            background: #d1fae5;
+            color: #065f46;
+        }
+
+        .doc-card .links {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .doc-card .link {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.75rem 1rem;
+            background: var(--bg-color);
+            border-radius: 0.5rem;
+            text-decoration: none;
+            color: var(--text-color);
+            font-weight: 500;
+            font-size: 0.9375rem;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+
+        .doc-card .link:hover {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .doc-card .link:hover svg {
+            stroke: white;
+        }
+
+        .doc-card .link svg {
+            width: 20px;
+            height: 20px;
+            stroke: var(--text-muted);
+            transition: stroke 0.2s ease;
+        }
+
+        .footer {
+            text-align: center;
+            padding: 2rem;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+            border-top: 1px solid var(--border-color);
+        }
+
+        .footer a {
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 500;
+        }
+
+        .footer a:hover {
+            text-decoration: underline;
+        }
+
+        .version-selector {
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .version-select {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            font-size: 0.9375rem;
+            background: var(--bg-color);
+            color: var(--text-color);
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 0.75rem center;
+            background-size: 1.25rem;
+            padding-right: 2.5rem;
+        }
+
+        .version-select:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(26, 159, 108, 0.15);
+        }
+
+        .version-nav-links {
+            display: flex;
+            gap: 0.75rem;
+        }
+
+        @media (max-width: 640px) {
+            .hero {
+                padding: 3rem 1.5rem;
+            }
+
+            .hero h1 {
+                font-size: 1.875rem;
+            }
+
+            .github-link {
+                position: relative;
+                top: auto;
+                right: auto;
+                margin-top: 1.5rem;
+                display: inline-flex;
+            }
+
+            .container {
+                padding: 2rem 1rem;
+            }
+        }
     </style>
-  </head>
-
-  <body>
-    <a href="https://github.com/puneetbehl/elasticsearch-grails-plugin"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"/></a>
-
-    <div id="container">
-    		<h1>Grails Elasticsearch Plugin</h1>
-    		<table id="properties">
-    		<tbody>
-    		<tr>
-    		  <td class="propName">Version</td>
-    		  <td>@VERSION@
-    		  <td>
-    		</tr>
-    		<tr>
-    		  <td class="propName">Grails Version</td>
-    		  <td>3.0 > *</td>
-    		</tr>
-    		<tr>
-    		  <td class="propName">Author</td>
-    		  <td>Puneet Behl</td>
-    		</tr>
-    		</tbody>
-    		</table>
-
-    		<hr/>
-
-    		<h2>Snapshot Documentation</h2>
-    		<ul>
-    			<li><a href="/elasticsearch-grails-plugin/snapshot/index.html">Documentation Snapshot</a></li>
-    			<li><a href="/elasticsearch-grails-plugin/snapshot/ref/index.html">Quick Reference</a></li>
-    		</ul>
-
-    		<h2>Grails 3.3.x and Elasticsearch 7.3 - 2.7.0.RC1 </h2>
-    		<ul>
-    		    <li><a href="/elasticsearch-grails-plugin/2.7.0.RC1/index.html">Latest Documentation</a></li>
-    		    <li><a href="/elasticsearch-grails-plugin/2.7.0.RC1/ref/index.html">Quick Reference</a></li>
-    		    <li><a href="/elasticsearch-grails-plugin/2.7.0.RC1/elasticsearch-2.7.0.RC1.pdf">User guide PDF</a></li>
-    		</ul>
-
-    		<h2>Previous Stable 2.5.0</h2>
-    		<ul>
-    		    <li><a href="/elasticsearch-grails-plugin/2.5.0/index.html">Latest Documentation</a></li>
-    		    <li><a href="/elasticsearch-grails-plugin/2.5.0/ref/index.html">Quick Reference</a></li>
-    		    <li><a href="/elasticsearch-grails-plugin/2.5.0/elasticsearch-2.4.0.pdf">User guide PDF</a></li>
-    		</ul>
-
-            <h2>Grails 3.3.x and Elasticsearch 7.3 beyond (version 2.7.x) </h2>
-            <ul>
-                <li><a href="/elasticsearch-grails-plugin/2.7.x/index.html">Latest Documentation</a></li>
-                <li><a href="/elasticsearch-grails-plugin/2.7.x/ref/index.html">Quick Reference</a></li>
-                <li><a href="/elasticsearch-grails-plugin/2.7.x/elasticsearch-2.7.0.RC1.pdf">User guide PDF</a></li>
-            </ul>
-
-    		<h2>Grails 3.1.x and beyond (version 2.4.x) </h2>
-    		<ul>
-    			<li><a href="/elasticsearch-grails-plugin/2.4.x/index.html">Latest Documentation</a></li>
-                <li><a href="/elasticsearch-grails-plugin/2.4.x/ref/index.html">Quick Reference</a></li>
-                <li><a href="/elasticsearch-grails-plugin/2.4.x/elasticsearch-2.4.0.pdf">User guide PDF</a></li>
-    		</ul>
-
-    		<h2>Grails 3.0.x (version 1.4.x)</h2>
-    		<ul>
-    			<li><a href="/elasticsearch-grails-plugin/1.4.x/index.html">Documentation</a></li>
-    			<li><a href="/elasticsearch-grails-plugin/1.4.x/ref/index.html">Quick Reference</a></li>
-    			<li><a href="/elasticsearch-grails-plugin/1.4.x/elasticsearch-grails-plugin.pdf">User guide PDF</a></li>
-    		</ul>
-
-    		<h2>Documentation (version 0.0.4.x)</h2>
-    		<ul>
-    			<li><a href="/elasticsearch-grails-plugin/0.0.4.x/index.html">Documentation</a></li>
-    		    <li><a href="/elasticsearch-grails-plugin/0.0.4.x/gapi/index.html">Groovy API docs</a></li>
-    			<li><a href="/elasticsearch-grails-plugin/0.0.4.x/guide/index.html">Manual (Page per chapter)</a></li>
-    			<li><a href="/elasticsearch-grails-plugin/0.0.4.x/guide/single.html">Manual (Single page)</a></li>
-    		</ul>
-
-    		<hr />
-
-    		<div class="download">
-    			<a href="https://github.com/puneetbehl/elasticsearch-grails-plugin/zipball/master">
-    				<img width="90" src="http://github.com/images/modules/download/zip.png">
-    			</a>
-    			<a href="https://github.com/puneetbehl/elasticsearch-grails-plugin/tarball/master">
-    				<img width="90" src="http://github.com/images/modules/download/tar.png">
-    			</a>
-    		</div>
-
-    		<h2>Download Source</h2>
-    		<p>
-    			You can download this project in either
-    			<a href="https://github.com/puneetbehl/elasticsearch-grails-plugin/zipball/master">zip</a> or
-    			<a href="https://github.com/puneetbehl/elasticsearch-grails-plugin/tarball/master">tar</a> formats.
-    		</p>
-    		<p>You can also clone the project with <a href="http://git-scm.com">Git</a> by running:
-    			<pre>$ git clone git://github.com/puneetbehl/elasticsearch-grails-plugin</pre>
-    		</p>
-
+</head>
+<body>
+    <header class="hero">
+        <a href="@GITHUB_REPO_URL@" class="github-link">
+            <svg viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+            </svg>
+            View on GitHub
+        </a>
+        <div class="hero-content">
+            <h1>@PROJECT_TITLE@</h1>
+            <p class="subtitle">@PROJECT_DESCRIPTION@</p>
         </div>
-  </body>
+    </header>
+
+    <main class="container">
+        <h2 class="section-title">Documentation</h2>
+
+        <div class="docs-grid">
+            <div class="doc-card">
+                <span class="version-badge latest">Latest Release</span>
+                <span class="version-badge latest">@LATEST_VERSION@</span>
+                <h3>Stable Version</h3>
+                <div class="links">
+                    <a href="/@REPO_SLUG@/latest/" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                        </svg>
+                        User Guide
+                    </a>
+                    <a href="/@REPO_SLUG@/latest/gapi/" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                        </svg>
+                        API Reference
+                    </a>
+                </div>
+            </div>
+
+            <div class="doc-card">
+                <span class="version-badge snapshot">Snapshot</span>
+                <h3>Development Version</h3>
+                <div class="links">
+                    <a href="/@REPO_SLUG@/snapshot/" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                        </svg>
+                        User Guide
+                    </a>
+                    <a href="/@REPO_SLUG@/snapshot/gapi/" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                        </svg>
+                        API Reference
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="section-title">Other Versions</h2>
+        <div class="doc-card" style="margin-bottom: 3rem;">
+            <div class="version-selector">
+                <select id="versionSelect" class="version-select">
+                    <option value="" disabled selected>Select a version&hellip;</option>
+                    @OTHER_VERSIONS_OPTIONS@
+                </select>
+                <div class="version-nav-links">
+                    <a id="versionUserGuide" href="#" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+                        </svg>
+                        User Guide
+                    </a>
+                    <a id="versionApiRef" href="#" class="link">
+                        <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                        </svg>
+                        API Reference
+                    </a>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        (function () {
+            var sel   = document.getElementById('versionSelect');
+            var guide = document.getElementById('versionUserGuide');
+            var api   = document.getElementById('versionApiRef');
+            function update() {
+                var v = sel.value;
+                if (!v) return;
+                guide.href = '/@REPO_SLUG@/' + v + '/';
+                api.href   = '/@REPO_SLUG@/' + v + '/gapi/';
+            }
+            sel.addEventListener('change', update);
+        })();
+    </script>
+
+    <footer class="footer">
+        <p>Built by the <a href="@GITHUB_ORG_URL@">@PROJECT_ORG@</a> team</p>
+    </footer>
+</body>
 </html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,12 @@
 projectVersion=5.0.0-SNAPSHOT
 grailsVersion=7.0.10
+# GitHub repository metadata
+githubUser=grails-plugins
+githubProject=grails-elasticsearch
+# Project metadata
+projectTitle=Elasticsearch Grails Plugin
+projectDescription=An Elasticsearch plugin for Grails. It allows indexing of domain class properties using a concise DSL and searching based on the domain classes using the Elasticsearch query api.
+projectOrg=Grails Plugins
 # Plugin specific properties
 elasticsearchVersion=7.17.29
 # Comma-separated list of projects to publish
@@ -7,7 +14,6 @@ projectsToPublish=grails-elasticsearch
 # Build dependencies
 asciidoctorVersion=4.0.3
 testLoggerVersion=4.0.0
-
 org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -80,15 +80,18 @@ tasks.withType(Test).configureEach {
 }
 
 extensions.configure(org.apache.grails.gradle.publish.GrailsPublishExtension) {
+    def githubUser    = rootProject.findProperty('githubUser')
+    def githubProject = rootProject.findProperty('githubProject')
     it.artifactId = project.name
-    it.githubSlug = 'grails-plugins/grails-elasticsearch'
+    it.githubSlug = "${githubUser}/${githubProject}"
     it.license.name = 'Apache-2.0'
-    it.title = 'Elasticsearch Grails Plugin'
-    it.desc = 'An Elasticsearch plugin for Grails. It allows indexing of domain class properties using a concise DSL and searching based on the domain classes using the Elasticsearch query api.'
+    it.title = "${projectTitle}"
+    it.desc = "${projectDescription}"
     it.organization {
-        it.name = 'Grails Plugins'
-        it.url = 'https://github.com/grails-plugins'
+        it.name = "${projectOrg}"
+        it.url = "https://github.com/${githubUser}"
     }
+
     it.developers = [
             puneetbehl: "Puneet Behl",
             noamt: "Noam Y. Tenne",


### PR DESCRIPTION
This pull request centralizes and parameterizes project and repository metadata, making it easier to maintain and update across the build and documentation configuration. The main improvements include introducing shared properties for GitHub and project metadata, updating build scripts to use these properties, and enhancing the documentation and publishing configuration for consistency and maintainability.

**Centralization of project and repository metadata:**

* Added new properties in `gradle.properties` for GitHub user and project, project title, description, and organization, making these values easily configurable in one place.

**Build and documentation configuration improvements:**

* Updated `docs/build.gradle` to use the centralized `githubUser` and `githubProject` properties for the `projectUrl` attribute, ensuring the documentation always references the correct repository.
* Enhanced the `ghPagesRootIndexPage` task in `config.docs.gradle` to use the new properties for constructing GitHub API URLs, repository links, and project metadata in the generated documentation index page. Also improved version sorting logic for documentation versions. [[1]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R76-R105) [[2]](diffhunk://#diff-91324e64885f9312141bec0a7bbffddb084741ae6b18aaa8d975dfbf2a47a777R114-R129)

**Publishing configuration improvements:**

* Modified `plugin/build.gradle` to use the shared properties for `githubSlug`, title, description, and organization in the publishing extension, ensuring consistency with the rest of the project metadata.

These changes make it much easier to update project or repository metadata in the future and ensure all documentation and publishing outputs stay in sync.